### PR TITLE
Add reference to youtube video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # keycap_playground
 The Keycap Playground is a parametric OpenSCAD keycap generator made for generating keycaps of all shapes and sizes (and profiles)
+
+
+For more information see [Video: Keycap Playground Alpha Demo](https://www.youtube.com/watch?v=WDlRZMvisA4). 


### PR DESCRIPTION
The README is currently sparse, adding a reference to the youtube demo would be helpful. 