### PR TITLE
Minor Python cleanup

### DIFF
--- a/scripts/gem_full.py
+++ b/scripts/gem_full.py
@@ -32,13 +32,12 @@ Fonts used by this script:
 # stdlib imports
 import os, sys
 from pathlib import Path
-import json
 import argparse
 from copy import deepcopy
 from subprocess import getstatusoutput
 # 3rd party stuff
-from colorama import Fore, Back, Style
-from colorama import init as color_init
+from colorama import Fore, Back, Style  # NOQA
+from colorama import init as color_init  # NOQA
 color_init()
 # Our own stuff
 from keycap import Keycap
@@ -76,7 +75,7 @@ class gem_base(Keycap):
         self.stem_side_supports = [0,0,0,0]
         self.stem_locations = [[0,0,0]]
         self.stem_walls_inset = 0
-        self.stem_sides_wall_thickness = 0.8; # Thick (good sound/feel)
+        self.stem_sides_wall_thickness = 0.8 # Thick (good sound/feel)
         # Because we do strange things we need legends bigger on the Z
         self.scale = [
             [1,1,3],
@@ -750,7 +749,7 @@ KEYCAPS = [
     gem_1_U_text(legends=["CYA"], scale=[[0.75,1,3]]),
     gem_1_U_text(legends=["IDK"], scale=[[0.75,1,3]]),
     gem_1_U_text(legends=["ASS"], scale=[[0.75,1,3]]),
-    gem_1_U_text(legends=["ANY", "", "KEY"], scale=[[0.75,1,3]], fonts = [
+    gem_1_U_text(legends=["ANY", "", "KEY"], scale=[[0.75,1,3]], fonts=[
             "Gotham Rounded:style=Bold",
             "Gotham Rounded:style=Bold",
             "Gotham Rounded:style=Bold",
@@ -899,7 +898,7 @@ def print_keycaps():
     Prints the names of all keycaps in KEYCAPS.
     """
     print(Style.BRIGHT +
-          f"Here's all the keycaps we can render:\n" + Style.RESET_ALL)
+          "Here's all the keycaps we can render:\n" + Style.RESET_ALL)
     keycap_names = ", ".join(a.name for a in KEYCAPS)
     print(f"{keycap_names}")
 

--- a/scripts/keycap.py
+++ b/scripts/keycap.py
@@ -336,7 +336,7 @@ class Keycap(object):
             f"LEGEND_ROTATION2={self.rotation2}; "
             f"LEGEND_SCALE={self.scale}; "
             f"LEGEND_UNDERSET={self.underset}; "
-# NOTE: For some reason I have to duplicate RENDER here for it to work properly:
+            # NOTE: For some reason I have to duplicate RENDER here for it to work properly:
             f"RENDER={json.dumps(render)};' "
             f"{last_part}"
         )

--- a/scripts/riskeyboard_70.py
+++ b/scripts/riskeyboard_70.py
@@ -11,12 +11,11 @@ to use this script is from within the `keycap_playground` directory.
 
 # stdlib imports
 import os, sys
-import json
 import argparse
 from copy import deepcopy
 from subprocess import getstatusoutput
 # 3rd party stuff
-from colorama import Fore, Back, Style
+from colorama import Fore, Back, Style  # NOQA
 from colorama import init as color_init
 color_init()
 # Our own stuff
@@ -42,7 +41,7 @@ class riskeyboard70_base(Keycap):
         # Disabled stem side support because it seems it is unnecessary @0.16mm
         self.stem_side_supports = [0,0,0,0]
         self.stem_locations = [[0,0,0]]
-        self.stem_sides_wall_thickness = 0.8; # Thick (good sound/feel)
+        self.stem_sides_wall_thickness = 0.8 # Thick (good sound/feel)
         # Because we do strange things we need legends bigger on the Z
         self.scale = [
             [1,1,3],
@@ -608,7 +607,7 @@ def print_keycaps():
     Prints the names of all keycaps in KEYCAPS.
     """
     print(Style.BRIGHT +
-          f"Here's all the keycaps we can render:\n" + Style.RESET_ALL)
+          "Here's all the keycaps we can render:\n" + Style.RESET_ALL)
     keycap_names = ", ".join(a.name for a in KEYCAPS)
     print(f"{keycap_names}")
 

--- a/scripts/riskeycap_full.py
+++ b/scripts/riskeycap_full.py
@@ -32,18 +32,17 @@ Fonts used by this script:
 # stdlib imports
 import os, sys
 from pathlib import Path
-import json
 import argparse
 from copy import deepcopy
-from subprocess import getstatusoutput
+# from subprocess import getstatusoutput
 import asyncio
 import subprocess
 from functools import partial
 from typing import Sequence, Any
 from asyncio import ensure_future
 # 3rd party stuff
-from colorama import Fore, Back, Style
-from colorama import init as color_init
+from colorama import Fore, Back, Style  # NOQA
+from colorama import init as color_init  # NOQA
 color_init()
 # Our own stuff
 from keycap import Keycap
@@ -147,7 +146,7 @@ class riskeycap_base(Keycap):
         self.stem_inside_tolerance = 0.175
         self.stem_side_supports = [0,0,0,0]
         self.stem_locations = [[0,0,0]]
-        self.stem_sides_wall_thickness = 0.8; # Thick (good sound/feel)
+        self.stem_sides_wall_thickness = 0.8 # Thick (good sound/feel)
         # Because we do strange things we need legends bigger on the Z
         self.scale = [
             [1,1,3],
@@ -809,7 +808,7 @@ KEYCAPS = [
     riskeycap_1_U_text(legends=["CYA"], scale=[[0.75,1,3]]),
     riskeycap_1_U_text(legends=["IDK"], scale=[[0.75,1,3]]),
     riskeycap_1_U_text(legends=["ASS"], scale=[[0.75,1,3]]),
-    riskeycap_1_U_text(legends=["ANY", "", "KEY"], scale=[[0.75,1,3]], fonts = [
+    riskeycap_1_U_text(legends=["ANY", "", "KEY"], scale=[[0.75,1,3]], fonts=[
             "Gotham Rounded:style=Bold",
             "Gotham Rounded:style=Bold",
             "Gotham Rounded:style=Bold",
@@ -961,7 +960,7 @@ KEYCAPS = [
     riskeycap_alphas(name="numpadstar", legends=["*"], font_sizes=[8.5]),
     # Default width of - is a bit too skinny so we scale/adjust it a bit:
     riskeycap_alphas(name="numpadminus", legends=["-"],
-        font_sizes=[6], scale=[[1.4,1,3]], trans = [[2.9,0,0]]),
+        font_sizes=[6], scale=[[1.4,1,3]], trans=[[2.9,0,0]]),
 ]
 
 def print_keycaps():
@@ -969,7 +968,7 @@ def print_keycaps():
     Prints the names of all keycaps in KEYCAPS.
     """
     print(Style.BRIGHT +
-          f"Here's all the keycaps we can render:\n" + Style.RESET_ALL)
+          "Here's all the keycaps we can render:\n" + Style.RESET_ALL)
     keycap_names = ", ".join(a.name for a in KEYCAPS)
     print(f"{keycap_names}")
 


### PR DESCRIPTION
This contains a minor cleanup for the Python code.

I removed unused imports (Added `# NOQA` to make linters happy about unused colorama imports, although maybe they can be removed? In any case I do recommend using the more modern [rich](https://rich.readthedocs.io/en/stable/introduction.html) library if you want pretty colors).

There were f-strings that didn't have any placeholders, so I removed the "f".

There were a few lines that ended with a semicolon, and those are removed.

There were a few inconsistencies in keyword argument assignments. I removed the spaces around the ` = ` in those cases to make them consistent. 


I also have a question: Is Python 2.7 or Python 3.5- support necessary? The `asyncio.coroutine` stuff is [deprecated](https://discuss.python.org/t/deprecation-of-asyncio-coroutine/4461), and that should be changed to `async def` instead. But if older Python support is required, then that stuff shouldn't change. 