### PR TITLE
Adding a readme for the python scripts and remove invalid -P argument to colorscad

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,6 @@
+
+# To Run These Scripts
+- Download [ColorSCAD](https://github.com/jschobben/colorscad)
+- Follow the [instructions included in the 3mfmerge](https://github.com/jschobben/colorscad/blob/master/3mfmerge/README.md) folder of the repo to build 3mfmerge
+- In the script you want to run (gem_full.py, riskkeycap_full.py, etc) update the `OPENSCAD_PATH` and `COLORSCAD_PATH` path variables
+- Run the scripts from the keycap_playground directory `$ ./scripts/riskeycap_full.py --out /tmp/output_dir`

--- a/scripts/gem_full.py
+++ b/scripts/gem_full.py
@@ -6,7 +6,7 @@ to use this script is from within the `keycap_playground` directory.
 
 .. bash::
 
-    $ ./scripts/riskeycap_full.py --out /tmp/output_dir
+    $ ./scripts/gem_full.py --out /tmp/output_dir
 
 .. note::
 

--- a/scripts/keycap.py
+++ b/scripts/keycap.py
@@ -269,7 +269,6 @@ class Keycap(object):
                     #f'PATH="${self.openscad_path.parent}:$PATH"; '
                     f"{self.colorscad_path} -i {self.keycap_playground_path} "
                     f"-o '{self.output_path}'/'{self.name}.{self.file_type}' "
-                    f"-p '{self.openscad_path}' "
                     f"-- {self.openscad_args} -D $'"
                 )
                 last_part = ""


### PR DESCRIPTION
while trying to run gem_full.py i found that the colorscad script doesn't have a -P argument into the script, so i've removed that from keycap.py, and i also added a small readme for the python scripts on how to get those running