### PR TITLE
fixing the json.dump breaking unicode characters

### DIFF
--- a/scripts/keycap.py
+++ b/scripts/keycap.py
@@ -233,7 +233,7 @@ class Keycap(object):
             elif legend == '"':
                 out += r'"\""'
             else:
-                out += json.dumps(legend) + ","
+                out += json.dumps(legend, ensure_ascii=False) + ","
         out = out.rstrip(',') # Get rid of trailing comma
         return out + "]"
 


### PR DESCRIPTION
this fixes unicode output for things like material design icon based keycaps

closes #20 